### PR TITLE
FIX more button menu

### DIFF
--- a/web_list_view_sticky/static/lib/sticky_table_header/sticky_table_headers.js
+++ b/web_list_view_sticky/static/lib/sticky_table_header/sticky_table_headers.js
@@ -141,7 +141,7 @@
 							'position': 'fixed',
 							'margin-top': base.options.marginTop,
 							'left': newLeft,
-							'z-index': 3 // #18: opacity bug
+							'z-index': 2 // #18: opacity bug
 						});
 						base.leftOffset = newLeft;
 						base.topOffset = newTopOffset;


### PR DESCRIPTION
Hi , When I have intalled this addon in my Odoo , and press the button " more " in a tree view the context menu is behind the header table , but only changed z -index: 3 for z -index: 2 the problem was
solved .
